### PR TITLE
remove the raise StopIteration() because it fails on python3. 

### DIFF
--- a/src/flask_cachecontrol/after_this_request.py
+++ b/src/flask_cachecontrol/after_this_request.py
@@ -33,7 +33,6 @@ class CallbackRegistry(object):
     def __iter__(self):
         while self._callbacks:
             yield self._callbacks.pop(0)
-        raise StopIteration()
 
 
 ########################################################################


### PR DESCRIPTION
I found a problem while using the Flask-CacheControl on python 3.

the problem is CallbackRegistry::__iter__. This method raises a StopIteration() and this creates a problem on python 3. 
see  https://www.python.org/dev/peps/pep-0479/

The correction is simple. We only need to remove the raise statement.