### PR TITLE
Allow for making cache control header status-code specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ def stats_view():
 def dashboard_view():
     return render_template('dashboard_template')
 ```
+
+## Breaking Changes:
+
+### v0.2.0
+- By default, cache control headers are only applied to successful requests. (status code `2xx`) This behaviour can be customized by providing `only_if=` as a kw to all caching decorators.
+- Requires python 3.3 or higher

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=[
         'Flask',
     ],
+    extras_require={'test': ["pytest"]},
     python_requires='>=3.3',
     classifiers=[
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=[
         'Flask',
     ],
+    python_requires='>=3.3',
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,3 @@
-"""
-Flask-CacheControl
-------------------
-
-A light-weight library to conveniently set Cache-Control
-headers on the response. Decorate view functions with
-cache_for, cache, or dont_cache decorators. Makes use of
-Flask response.cache_control.
-
-This extension does not provide any caching of its own. Its sole
-purpose is to set Cache-Control and related HTTP headers on the
-response, so that clients, intermediary proxies or reverse proxies
-in your jurisdiction which evaluate Cache-Control headers, such as
-Varnish Cache, do the caching for you.
-"""
-
 import ast
 import re
 from setuptools import setup
@@ -24,7 +8,6 @@ with open('src/flask_cachecontrol/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
 
-
 setup(
     name='Flask-CacheControl',
     version=version,
@@ -33,7 +16,8 @@ setup(
     author='Thomas Wiebe',
     author_email='code@heimblick.net',
     description='Set Cache-Control headers on the Flask response',
-    long_description=__doc__,
+    long_description=open('README.md', 'r').read(),
+    long_description_content_type="text/markdown",
     package_dir={'': 'src'},
     packages=['flask_cachecontrol'],
     zip_safe=False,

--- a/src/flask_cachecontrol/__init__.py
+++ b/src/flask_cachecontrol/__init__.py
@@ -18,7 +18,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from .cache import cache, cache_for, dont_cache, FlaskCacheControl
+from .cache import cache, cache_for, dont_cache, FlaskCacheControl, Always, ResponseIsSuccessful
 from .error import FlaskCacheControlError, CacheControlAttributeInvalidError
 
 __version__ = '0.1.3'

--- a/src/flask_cachecontrol/__init__.py
+++ b/src/flask_cachecontrol/__init__.py
@@ -21,4 +21,4 @@
 from .cache import cache, cache_for, dont_cache, FlaskCacheControl, Always, ResponseIsSuccessful
 from .error import FlaskCacheControlError, CacheControlAttributeInvalidError
 
-__version__ = '0.1.3'
+__version__ = '0.2.0'

--- a/src/flask_cachecontrol/after_this_request.py
+++ b/src/flask_cachecontrol/after_this_request.py
@@ -6,16 +6,18 @@
     :copyright: (c) 2015 by Thomas Wiebe.
     :license: BSD, see LICENSE for more details.
 """
+from abc import ABCMeta, abstractmethod
 
 from flask import g
 
 
-class CallbackBase(object):
+class CallbackBase(metaclass=ABCMeta):
+    @abstractmethod
     def __call__(self, response):
-        raise NotImplementedError()
+        pass
 
 
-class CallbackRegistry(object):
+class CallbackRegistry:
     def __init__(self):
         self._callbacks = []
 
@@ -27,12 +29,12 @@ class CallbackRegistry(object):
             yield self._callbacks.pop(0)
 
 
-class AfterThisRequestCallbackRegistryProvider(object):
+class AfterThisRequestCallbackRegistryProvider:
     def provide(self):
         return g.after_this_request_callback_registry
 
 
-class AfterThisRequestResponseProcessor(object):
+class AfterThisRequestResponseProcessor:
     def __init__(self, response):
         self._response = response
         self._callback_registry = None
@@ -51,7 +53,7 @@ class AfterThisRequestResponseProcessor(object):
         self._callback(self._response)
 
 
-class AfterThisRequestResponseHandler(object):
+class AfterThisRequestResponseHandler:
     def __call__(self, response):
         self._process_response(response)
         return response
@@ -61,7 +63,7 @@ class AfterThisRequestResponseHandler(object):
         processor.process()
 
 
-class AfterThisRequestRequestHandler(object):
+class AfterThisRequestRequestHandler:
     def __call__(self):
         if not self._callback_registry_set_up_on_g():
             self._setup_callback_registry_on_g()

--- a/src/flask_cachecontrol/after_this_request.py
+++ b/src/flask_cachecontrol/after_this_request.py
@@ -10,90 +10,64 @@
 from flask import g
 
 
-########################################################################
 class CallbackBase(object):
-
-    #----------------------------------------------------------------------
     def __call__(self, response):
         raise NotImplementedError()
 
 
-########################################################################
 class CallbackRegistry(object):
-
-    #----------------------------------------------------------------------
     def __init__(self):
         self._callbacks = []
 
-    #----------------------------------------------------------------------
     def add(self, callback):
         self._callbacks.append(callback)
 
-    #----------------------------------------------------------------------
     def __iter__(self):
         while self._callbacks:
             yield self._callbacks.pop(0)
 
 
-########################################################################
 class AfterThisRequestCallbackRegistryProvider(object):
-
-    #----------------------------------------------------------------------
     def provide(self):
         return g.after_this_request_callback_registry
 
 
-########################################################################
 class AfterThisRequestResponseProcessor(object):
-
-    #----------------------------------------------------------------------
     def __init__(self, response):
         self._response = response
         self._callback_registry = None
         self._callback = None
 
-    #----------------------------------------------------------------------
     def process(self):
         self._fetch_callback_registry()
         for self._callback in self._callback_registry:
             self._execute_callback()
 
-    #----------------------------------------------------------------------
     def _fetch_callback_registry(self):
         provider = AfterThisRequestCallbackRegistryProvider()
         self._callback_registry = provider.provide()
 
-    #----------------------------------------------------------------------
     def _execute_callback(self):
         self._callback(self._response)
 
 
-########################################################################
 class AfterThisRequestResponseHandler(object):
-
-    #----------------------------------------------------------------------
     def __call__(self, response):
         self._process_response(response)
         return response
 
-    #----------------------------------------------------------------------
     def _process_response(self, response):
         processor = AfterThisRequestResponseProcessor(response)
         processor.process()
 
 
-########################################################################
 class AfterThisRequestRequestHandler(object):
-
-    #----------------------------------------------------------------------
     def __call__(self):
         if not self._callback_registry_set_up_on_g():
             self._setup_callback_registry_on_g()
 
-    #----------------------------------------------------------------------
     def _callback_registry_set_up_on_g(self):
         return getattr(g, 'after_this_request_callback_registry', None) is not None
 
-    #----------------------------------------------------------------------
     def _setup_callback_registry_on_g(self):
         g.after_this_request_callback_registry = CallbackRegistry()

--- a/src/flask_cachecontrol/cache.py
+++ b/src/flask_cachecontrol/cache.py
@@ -39,7 +39,6 @@ class ResponseIsSuccessful(OnlyIfEvaluatorBase):
         return 200 <= response.status_code < 300
 
 
-#----------------------------------------------------------------------
 def cache_for(only_if=ResponseIsSuccessful, **timedelta_kw):
     """
     Set Cache-Control headers and Expires-header.
@@ -66,7 +65,6 @@ def cache_for(only_if=ResponseIsSuccessful, **timedelta_kw):
     return decorate_func
 
 
-#----------------------------------------------------------------------
 def cache(*cache_control_items, only_if=ResponseIsSuccessful, **cache_control_kw):
     """
     Set Cache-Control headers.
@@ -101,7 +99,6 @@ def cache(*cache_control_items, only_if=ResponseIsSuccessful, **cache_control_kw
     return decorate_func
 
 
-#----------------------------------------------------------------------
 def dont_cache(only_if=ResponseIsSuccessful):
     """
     Set Cache-Control headers for no caching
@@ -127,24 +124,18 @@ def dont_cache(only_if=ResponseIsSuccessful):
     return decorate_func
 
 
-########################################################################
 class FlaskCacheControl(object):
-
-    #----------------------------------------------------------------------
     def __init__(self, app=None):
         self._app = app
         if app:
             self.init_app(app)
 
-    #----------------------------------------------------------------------
     def init_app(self, app):
         self._register_request_handler(app)
         self._register_response_handler(app)
 
-    #----------------------------------------------------------------------
     def _register_request_handler(self, app):
         app.before_request(AfterThisRequestRequestHandler())
 
-    #----------------------------------------------------------------------
     def _register_response_handler(self, app):
         app.after_request(AfterThisRequestResponseHandler())

--- a/src/flask_cachecontrol/cache.py
+++ b/src/flask_cachecontrol/cache.py
@@ -6,7 +6,7 @@
     :copyright: (c) 2015 by Thomas Wiebe.
     :license: BSD, see LICENSE for more details.
 """
-
+from abc import ABCMeta, abstractmethod
 from datetime import timedelta
 from functools import wraps
 
@@ -16,12 +16,39 @@ from .callback import SetCacheControlHeadersCallback
 from .callback import SetCacheControlHeadersFromTimedeltaCallback, SetCacheControlHeadersForNoCachingCallback
 
 
+class OnlyIfEvaluatorBase(metaclass=ABCMeta):
+    def __init__(self, callback):
+        self._callback = callback
+
+    def __call__(self, response):
+        if self._response_qualifies(response):
+            self._callback(response)
+
+    @abstractmethod
+    def _response_qualifies(self, response):
+        pass
+
+
+class Always(OnlyIfEvaluatorBase):
+    def _response_qualifies(self, response):
+        return True
+
+
+class ResponseIsSuccessful(OnlyIfEvaluatorBase):
+    def _response_qualifies(self, response):
+        return 200 <= response.status_code < 300
+
+
 #----------------------------------------------------------------------
-def cache_for(**timedelta_kw):
+def cache_for(only_if=ResponseIsSuccessful, **timedelta_kw):
     """
     Set Cache-Control headers and Expires-header.
 
     Expects a timedelta instance.
+
+    By default only applies to successful requests (2xx status code).
+    Provide only_if=None to apply to all requests or supply custom
+    evaluator for customized behaviour.
     """
     max_age_timedelta = timedelta(**timedelta_kw)
 
@@ -29,6 +56,8 @@ def cache_for(**timedelta_kw):
         @wraps(func)
         def decorate_func_call(*a, **kw):
             callback = SetCacheControlHeadersFromTimedeltaCallback(max_age_timedelta)
+            if only_if is not None:
+                callback = only_if(callback)
             registry_provider = AfterThisRequestCallbackRegistryProvider()
             registry = registry_provider.provide()
             registry.add(callback)
@@ -38,7 +67,7 @@ def cache_for(**timedelta_kw):
 
 
 #----------------------------------------------------------------------
-def cache(*cache_control_items, **cache_control_kw):
+def cache(*cache_control_items, only_if=ResponseIsSuccessful, **cache_control_kw):
     """
     Set Cache-Control headers.
 
@@ -51,6 +80,10 @@ def cache(*cache_control_items, **cache_control_kw):
 
     In case of an invalid attribute, CacheControlAttributeInvalidError
     will be thrown.
+
+    By default only applies to successful requests (2xx status code).
+    Provide only_if=None to apply to all requests or supply custom
+    evaluator for customized behaviour.
     """
     cache_control_kw.update(cache_control_items)
 
@@ -58,6 +91,8 @@ def cache(*cache_control_items, **cache_control_kw):
         @wraps(func)
         def decorate_func_call(*a, **kw):
             callback = SetCacheControlHeadersCallback(**cache_control_kw)
+            if only_if is not None:
+                callback = only_if(callback)
             registry_provider = AfterThisRequestCallbackRegistryProvider()
             registry = registry_provider.provide()
             registry.add(callback)
@@ -67,17 +102,23 @@ def cache(*cache_control_items, **cache_control_kw):
 
 
 #----------------------------------------------------------------------
-def dont_cache():
+def dont_cache(only_if=ResponseIsSuccessful):
     """
     Set Cache-Control headers for no caching
 
     Will generate proxy-revalidate, no-cache, no-store, must-revalidate,
     max-age=0.
+
+    By default only applies to successful requests (2xx status code).
+    Provide only_if=None to apply to all requests or supply custom
+    evaluator for customized behaviour.
     """
     def decorate_func(func):
         @wraps(func)
         def decorate_func_call(*a, **kw):
             callback = SetCacheControlHeadersForNoCachingCallback()
+            if only_if is not None:
+                callback = only_if(callback)
             registry_provider = AfterThisRequestCallbackRegistryProvider()
             registry = registry_provider.provide()
             registry.add(callback)

--- a/src/flask_cachecontrol/cache.py
+++ b/src/flask_cachecontrol/cache.py
@@ -124,7 +124,7 @@ def dont_cache(only_if=ResponseIsSuccessful):
     return decorate_func
 
 
-class FlaskCacheControl(object):
+class FlaskCacheControl:
     def __init__(self, app=None):
         self._app = app
         if app:

--- a/src/flask_cachecontrol/callback.py
+++ b/src/flask_cachecontrol/callback.py
@@ -13,27 +13,19 @@ from .after_this_request import CallbackBase
 from .error import CacheControlAttributeInvalidError
 
 
-########################################################################
 class SetCacheControlHeadersFromTimedeltaCallback(CallbackBase):
-
-    #----------------------------------------------------------------------
     def __init__(self, timedelta):
         self._timedelta = timedelta
 
-    #----------------------------------------------------------------------
     def __call__(self, response):
         response.expires = datetime.utcnow() + self._timedelta
         response.cache_control.max_age = int(self._timedelta.total_seconds())
 
 
-########################################################################
 class SetCacheControlHeadersCallback(CallbackBase):
-
-    #----------------------------------------------------------------------
     def __init__(self, **cache_control_kw):
         self._cache_control_kw = cache_control_kw
 
-    #----------------------------------------------------------------------
     def __call__(self, response):
         cache_control = response.cache_control
         for attr_name, value in self._cache_control_kw.items():
@@ -42,10 +34,7 @@ class SetCacheControlHeadersCallback(CallbackBase):
             setattr(cache_control, attr_name, value)
 
 
-########################################################################
 class SetCacheControlHeadersForNoCachingCallback(CallbackBase):
-
-    #----------------------------------------------------------------------
     def __call__(self, response):
         response.cache_control.max_age = 0
         response.cache_control.no_cache = True

--- a/src/flask_cachecontrol/error.py
+++ b/src/flask_cachecontrol/error.py
@@ -8,19 +8,14 @@
 """
 
 
-########################################################################
 class FlaskCacheControlError(Exception):
     pass
 
 
-########################################################################
 class CacheControlAttributeInvalidError(FlaskCacheControlError):
-
-    #----------------------------------------------------------------------
     def __init__(self, attr_name):
         self.attr_name = attr_name
 
-    #----------------------------------------------------------------------
     def __str__(self):
         return 'Attribute {!r} not a valid Flask Cache-Control parameter'.format(
             self.attr_name)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,141 @@
+import pytest
+from flask import Flask, Response
+from flask_cachecontrol import FlaskCacheControl, cache_for, cache, dont_cache, ResponseIsSuccessful, Always
+
+app = Flask(__name__)
+
+flask_cache_control = FlaskCacheControl(app)
+
+
+@app.route('/cache_for/on_success/<int:status_code>')
+@cache_for(only_if=ResponseIsSuccessful, seconds=300)
+def view_cache_for_on_success(status_code):
+    return Response(status=status_code)
+
+
+@app.route('/cache_for/always/<int:status_code>')
+@cache_for(only_if=Always, seconds=300)
+def view_cache_for_always(status_code):
+    return Response(status=status_code)
+
+
+@app.route('/dont_cache/always/<int:status_code>')
+@dont_cache(only_if=Always)
+def view_dont_cache_always(status_code):
+    return Response(status=status_code)
+
+
+@app.route('/dont_cache/on_success/<int:status_code>')
+@dont_cache(only_if=ResponseIsSuccessful)
+def view_dont_cache_on_success(status_code):
+    return Response(status=status_code)
+
+
+@app.route('/cache/always/<int:status_code>')
+@cache(no_store=True, only_if=Always)
+def view_cache_always(status_code):
+    return Response(status=status_code)
+
+
+@app.route('/cache/on_success/<int:status_code>')
+@cache(no_store=True, only_if=ResponseIsSuccessful)
+def view_cache_on_success(status_code):
+    return Response(status=status_code)
+
+
+@app.route('/cache/always_only_if_none/<int:status_code>')
+@cache(no_store=True, only_if=None)
+def view_cache_on_success_only_if_none(status_code):
+    return Response(status=status_code)
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+
+    with app.test_client() as client:
+        yield client
+
+
+def test_cache_for_always_works_for_200(client):
+    rv = client.get('/cache_for/always/200')
+    assert 'Cache-Control' in rv.headers and rv.headers['Cache-Control'] == 'max-age=300'
+    assert 'Expires' in rv.headers
+
+
+def test_cache_for_always_works_for_404(client):
+    rv = client.get('/cache_for/always/404')
+    assert 'Cache-Control' in rv.headers and rv.headers['Cache-Control'] == 'max-age=300'
+    assert 'Expires' in rv.headers
+
+
+def test_cache_for_on_success_works_on_success(client):
+    rv = client.get('/cache_for/on_success/200')
+    assert 'Cache-Control' in rv.headers
+
+
+def test_cache_for_on_success_works_not_on_failure(client):
+    rv = client.get('/cache_for/on_success/300')
+    assert 'Cache-Control' not in rv.headers
+    rv = client.get('/cache_for/on_success/404')
+    assert 'Cache-Control' not in rv.headers
+
+
+def test_dont_cache_always_works_on_success(client):
+    rv = client.get('/dont_cache/always/200')
+    assert 'Cache-Control' in rv.headers and 'no-cache' in rv.headers['Cache-Control']
+
+
+def test_dont_cache_always_works_on_failure(client):
+    rv = client.get('/dont_cache/always/404')
+    assert 'Cache-Control' in rv.headers and 'no-cache' in rv.headers['Cache-Control']
+
+
+def test_dont_cache_on_success_works_on_success(client):
+    rv = client.get('/dont_cache/on_success/200')
+    assert 'Cache-Control' in rv.headers and 'no-cache' in rv.headers['Cache-Control']
+
+
+def test_dont_cache_on_success_works_not_on_failure(client):
+    rv = client.get('/dont_cache/on_success/404')
+    assert 'Cache-Control' not in rv.headers
+
+
+def test_cache_always_works_on_success(client):
+    rv = client.get('/cache/always/200')
+    assert 'Cache-Control' in rv.headers \
+           and 'no-store' in rv.headers['Cache-Control'] \
+           and 'no-cache' not in rv.headers['Cache-Control']
+
+
+def test_cache_always_works_on_failure(client):
+    rv = client.get('/cache/always/404')
+    assert 'Cache-Control' in rv.headers \
+           and 'no-store' in rv.headers['Cache-Control'] \
+           and 'no-cache' not in rv.headers['Cache-Control']
+
+
+def test_cache_on_success_works_on_success(client):
+    rv = client.get('/cache/on_success/200')
+    assert 'Cache-Control' in rv.headers \
+           and 'no-store' in rv.headers['Cache-Control'] \
+           and 'no-cache' not in rv.headers['Cache-Control']
+
+
+def test_cache_on_success_works_not_on_failure(client):
+    rv = client.get('/cache/on_success/404')
+    assert 'Cache-Control' not in rv.headers
+
+
+def test_cache_always_works_on_success_with_only_if_none(client):
+    rv = client.get('/cache/always_only_if_none/200')
+    assert 'Cache-Control' in rv.headers \
+           and 'no-store' in rv.headers['Cache-Control'] \
+           and 'no-cache' not in rv.headers['Cache-Control']
+
+
+def test_cache_always_works_on_failure_with_only_if_none(client):
+    rv = client.get('/cache/always_only_if_none/404')
+    assert 'Cache-Control' in rv.headers \
+           and 'no-store' in rv.headers['Cache-Control'] \
+           and 'no-cache' not in rv.headers['Cache-Control']


### PR DESCRIPTION
Issue #2 describes the need to be able to set caching headers only for successful requests. This branch implements this.

It does this in a breaking change: the headers are by default only set for successful requests. `only_if=` kw is available in all decorators to allow for customization. Set to `None` or `Always` to bypass the successful request filter. Provide your own callable for further customization.

Also, these changes do away with the now officially unsupported py2.