### PR TITLE
Fix import notation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Varnish Cache, do the caching for you.
 
 ## Example:
 ```python
-from flask.ext.cachecontrol import (
+from flask_cachecontrol import (
     FlaskCacheControl,
     cache,
     cache_for,


### PR DESCRIPTION
The import in the current README is failing. Updated.